### PR TITLE
Extract the implementation of creating a JWT into a separate provider

### DIFF
--- a/src/main/java/io/jenkins/plugin/auth/jwt/JwtAuthenticationService.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/JwtAuthenticationService.java
@@ -8,6 +8,8 @@ import org.kohsuke.stapler.verb.GET;
 
 import javax.annotation.Nullable;
 
+import io.jenkins.plugin.auth.jwt.impl.JwtAuthenticationServiceImpl;
+
 /**
  * JWT endpoint resource. Provides functionality to get JWT token and also provides JWK endpoint to get
  * public key using keyId.
@@ -33,8 +35,9 @@ public abstract class JwtAuthenticationService implements UnprotectedRootAction,
      */
     @GET
     @WebMethod(name = "token")
-    public abstract JwtToken getToken(@Nullable @QueryParameter("expiryTimeInMins") Integer expiryTimeInMins,
-                                          @Nullable  @QueryParameter("maxExpiryTimeInMins") Integer maxExpiryTimeInMins);
+    public abstract JwtAuthenticationServiceImpl.JwtResponse getToken(
+            @Nullable @QueryParameter("expiryTimeInMins") Integer expiryTimeInMins,
+            @Nullable  @QueryParameter("maxExpiryTimeInMins") Integer maxExpiryTimeInMins);
 
     /**
      * Binds Json web key to the URL space.

--- a/src/main/java/io/jenkins/plugin/auth/jwt/JwtToken.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/JwtToken.java
@@ -1,29 +1,20 @@
 package io.jenkins.plugin.auth.jwt;
 
-import io.jenkins.plugin.auth.jwt.commons.JsonConverter;
-import io.jenkins.plugin.auth.jwt.commons.ServiceException;
-import net.sf.json.JSONObject;
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwx.HeaderParameterNames;
 import org.jose4j.lang.JoseException;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.ServletException;
-import java.io.IOException;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.jenkins.plugin.auth.jwt.commons.ServiceException;
+import net.sf.json.JSONObject;
 
 /**
  * Generates JWT token
  *
  * @author Vivek Pandey
  */
-public class JwtToken implements HttpResponse {
+public class JwtToken {
     private static final Logger LOGGER = LoggerFactory.getLogger(JwtToken.class);
 
     /**
@@ -66,32 +57,4 @@ public class JwtToken implements HttpResponse {
         throw new IllegalStateException("No key is available to sign a token");
     }
 
-    /**
-     * Writes the token as an HTTP response.
-     * The JWT gets used as an access token, so mimic the OAuth access token response:
-     *  https://tools.ietf.org/html/rfc6749#section-4.1.4
-     */
-    @Override
-    public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
-        String access_token = sign();
-
-        int expiresIn = Integer.parseInt(claim.getString("exp")) - Integer.parseInt(claim.getString("iat"));
-        OAuthAccessTokenResponse payload = new OAuthAccessTokenResponse(access_token, expiresIn);
-
-        rsp.setContentType("application/json");
-        rsp.getWriter().write(JsonConverter.toJson(payload));
-    }
-
-    @JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
-    private static final class OAuthAccessTokenResponse {
-        public final String accessToken;
-        public final String tokenType;
-        public final int expiresIn; // seconds
-
-        private OAuthAccessTokenResponse(String accessToken, int expiresIn) {
-            this.accessToken = accessToken;
-            this.tokenType = "bearer";
-            this.expiresIn = expiresIn;
-        }
-    }
 }

--- a/src/main/java/io/jenkins/plugin/auth/jwt/impl/JwtAuthenticationFilter.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/impl/JwtAuthenticationFilter.java
@@ -33,14 +33,25 @@ public class JwtAuthenticationFilter implements Filter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
-    public static final String FEATURE_JWT_AUTHENTICATION_PROPERTY = "FEATURE_JWT_AUTHENTICATION";
-    // Legacy feature flag for toggling this feature when it was part of blueocean
-    public static final String LEGACY_FEATURE_JWT_AUTHENTICATION_PROPERTY = "BLUEOCEAN_FEATURE_JWT_AUTHENTICATION";
     /**
      * Used to mark requests that had a valid JWT token.
      */
     private static final String JWT_TOKEN_VALIDATED = JwtAuthenticationFilter.class.getName()+".validated";
-    private boolean isJwtEnabled;
+
+    private boolean isJwtEnabled = true;
+
+    public boolean isEnabled() {
+        return isJwtEnabled;
+    }
+
+    /**
+     * Enable or disable JWT Authentication
+     * @param enable true to enable JWT Authentication, false to disable
+     */
+    public void enable(boolean enable) {
+        isJwtEnabled = enable;
+        LOGGER.info("JWT Authentication enabled: {} ", enable);
+    }
 
     @Initializer(fatal=false)
     public static void init() throws ServletException {
@@ -49,16 +60,7 @@ public class JwtAuthenticationFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        /**
-         * Initialize jwt enabled flag by reading FEATURE_JWT_AUTHENTICATION_PROPERTY jvm property
-         *
-         * {@link io.jenkins.plugin.auth.jwt.commons.BlueOceanConfigProperties.FEATURE_JWT_AUTHENTICATION} doesn't
-         * work in certain test scenario - specially when test sets this JVM property to enable JWT but this class has
-         * already been loaded setting it to false.
-         *
-         */
-        this.isJwtEnabled = Boolean.getBoolean(FEATURE_JWT_AUTHENTICATION_PROPERTY) ||
-                Boolean.getBoolean(LEGACY_FEATURE_JWT_AUTHENTICATION_PROPERTY);
+        LOGGER.info("JWT Authentication enabled: {}", isJwtEnabled);
     }
 
     @Override
@@ -69,7 +71,6 @@ public class JwtAuthenticationFilter implements Filter {
             chain.doFilter(req,rsp);
             return;
         }
-
 
         Authentication token = verifyToken(request);
 

--- a/src/main/java/io/jenkins/plugin/auth/jwt/impl/JwtAuthenticationFilter.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/impl/JwtAuthenticationFilter.java
@@ -104,7 +104,7 @@ public class JwtAuthenticationFilter implements Filter {
     Authentication verifyToken(HttpServletRequest request) {
         // Get the token from the request
         String authHeader = request.getHeader("Authorization");
-        if(authHeader == null || !authHeader.startsWith("Bearer ")){
+        if(authHeader == null || !authHeader.toLowerCase().startsWith("bearer ")){
             return null;
         }
         String token = authHeader.substring("Bearer ".length());

--- a/src/main/java/io/jenkins/plugin/auth/jwt/impl/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/impl/JwtAuthenticationServiceImpl.java
@@ -32,6 +32,8 @@ public class JwtAuthenticationServiceImpl extends JwtAuthenticationService {
 
     @Override
     public JwtToken getToken(@Nullable @QueryParameter("expiryTimeInMins") Integer expiryTimeInMins, @Nullable @QueryParameter("maxExpiryTimeInMins") Integer maxExpiryTimeInMins) {
+        // The token endpoint is protected, ie - only issue tokens valid for the authorization strategy
+        Jenkins.getInstance().checkPermission(Jenkins.READ);
         long expiryTime= Long.getLong("EXPIRY_TIME_IN_MINS",DEFAULT_EXPIRY_IN_SEC);
 
         int maxExpiryTime = Integer.getInteger("MAX_EXPIRY_TIME_IN_MINS",DEFAULT_MAX_EXPIRY_TIME_IN_MIN);

--- a/src/main/java/io/jenkins/plugin/auth/jwt/impl/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/impl/JwtAuthenticationServiceImpl.java
@@ -1,22 +1,17 @@
 package io.jenkins.plugin.auth.jwt.impl;
 
 import hudson.Extension;
-import hudson.Plugin;
-import hudson.model.User;
-import hudson.tasks.Mailer;
 import io.jenkins.plugin.auth.jwt.JwtAuthenticationService;
 import io.jenkins.plugin.auth.jwt.JwtAuthenticationStore;
 import io.jenkins.plugin.auth.jwt.JwtAuthenticationStoreFactory;
 import io.jenkins.plugin.auth.jwt.JwtToken;
-import io.jenkins.plugin.auth.jwt.commons.ServiceException;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
+
+import io.jenkins.plugin.auth.jwt.tokens.JwtGenerator;
 import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.UUID;
 
 /**
  * Default implementation of {@link JwtAuthenticationService}
@@ -26,72 +21,14 @@ import java.util.UUID;
 @Extension
 public class JwtAuthenticationServiceImpl extends JwtAuthenticationService {
 
-    private static int DEFAULT_EXPIRY_IN_SEC = 1800;
-    private static int DEFAULT_MAX_EXPIRY_TIME_IN_MIN = 480;
-    private static int DEFAULT_NOT_BEFORE_IN_SEC = 30;
-
     @Override
     public JwtToken getToken(@Nullable @QueryParameter("expiryTimeInMins") Integer expiryTimeInMins, @Nullable @QueryParameter("maxExpiryTimeInMins") Integer maxExpiryTimeInMins) {
-        // The token endpoint is protected, ie - only issue tokens valid for the authorization strategy
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
-        long expiryTime= Long.getLong("EXPIRY_TIME_IN_MINS",DEFAULT_EXPIRY_IN_SEC);
-
-        int maxExpiryTime = Integer.getInteger("MAX_EXPIRY_TIME_IN_MINS",DEFAULT_MAX_EXPIRY_TIME_IN_MIN);
-
-        if(maxExpiryTimeInMins != null){
-            maxExpiryTime = maxExpiryTimeInMins;
-        }
-        if(expiryTimeInMins != null){
-            if(expiryTimeInMins > maxExpiryTime) {
-                throw new ServiceException.BadRequestException(
-                    String.format("expiryTimeInMins %s can't be greater than %s", expiryTimeInMins, maxExpiryTime));
-            }
-            expiryTime = expiryTimeInMins * 60;
-        }
-
-        Authentication authentication = Jenkins.getAuthentication();
-
-        String userId = authentication.getName();
-
-        User user = User.get(userId, false, Collections.emptyMap());
-        String email = null;
-        String fullName = null;
-        if(user != null) {
-            fullName = user.getFullName();
-            userId = user.getId();
-            Mailer.UserProperty p = user.getProperty(Mailer.UserProperty.class);
-            if(p!=null)
-                email = p.getAddress();
-        }
-        Plugin plugin = Jenkins.getInstance().getPlugin("plugin-jwt");
-        String issuer = "plugin-jwt:"+ ((plugin!=null) ? plugin.getWrapper().getVersion() : "");
-
-        JwtToken jwtToken = new JwtToken();
-        jwtToken.claim.put("jti", UUID.randomUUID().toString().replace("-",""));
-        jwtToken.claim.put("iss", issuer);
-        jwtToken.claim.put("sub", userId);
-        jwtToken.claim.put("name", fullName);
-        long currentTime = System.currentTimeMillis()/1000;
-        jwtToken.claim.put("iat", currentTime);
-        jwtToken.claim.put("exp", currentTime+expiryTime);
-        jwtToken.claim.put("nbf", currentTime - DEFAULT_NOT_BEFORE_IN_SEC);
-
-        //set claim
-        JSONObject context = new JSONObject();
-
-        JSONObject userObject = new JSONObject();
-        userObject.put("id", userId);
-        userObject.put("fullName", fullName);
-        userObject.put("email", email);
-
-        JwtAuthenticationStore authenticationStore = getJwtStore(authentication);
-
-        authenticationStore.store(authentication, context);
-
-        context.put("user", userObject);
-        jwtToken.claim.put("context", context);
-
-        return jwtToken;
+        return JwtGenerator.all()
+                    .stream()
+                    .findFirst()
+                    .map(generator -> generator.getToken(
+                            Jenkins.getAuthentication(), expiryTimeInMins, maxExpiryTimeInMins))
+                    .orElseThrow(() -> new RuntimeException("No JwtGenerators found"));
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugin/auth/jwt/tokens/InternalJwtGenerator.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/tokens/InternalJwtGenerator.java
@@ -1,0 +1,116 @@
+package io.jenkins.plugin.auth.jwt.tokens;
+
+import java.util.Collections;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+import org.acegisecurity.Authentication;
+import org.kohsuke.stapler.QueryParameter;
+import io.jenkins.plugin.auth.jwt.JwtAuthenticationStore;
+import io.jenkins.plugin.auth.jwt.JwtAuthenticationStoreFactory;
+import io.jenkins.plugin.auth.jwt.JwtToken;
+import io.jenkins.plugin.auth.jwt.commons.ServiceException;
+import io.jenkins.plugin.auth.jwt.impl.SimpleJwtAuthenticationStore;
+import net.sf.json.JSONObject;
+
+import hudson.Extension;
+import hudson.Plugin;
+import hudson.model.User;
+import hudson.security.AccessDeniedException2;
+import hudson.tasks.Mailer;
+import jenkins.model.Jenkins;
+
+/**
+ * A {@link JwtGenerator} that generates an internally signed JWT.
+ */
+@Extension(ordinal = -999)
+public class InternalJwtGenerator extends JwtGenerator {
+
+    private static int DEFAULT_EXPIRY_IN_SEC = 1800;
+    private static int DEFAULT_MAX_EXPIRY_TIME_IN_MIN = 480;
+    private static int DEFAULT_NOT_BEFORE_IN_SEC = 30;
+
+    public static JwtAuthenticationStore getJwtStore(Authentication authentication) {
+        JwtAuthenticationStore jwtAuthenticationStore = null;
+        for (JwtAuthenticationStoreFactory factory : JwtAuthenticationStoreFactory.all()) {
+            if (factory instanceof SimpleJwtAuthenticationStore) {
+                jwtAuthenticationStore = factory.getJwtAuthenticationStore(authentication);
+                continue;
+            }
+            JwtAuthenticationStore authenticationStore = factory.getJwtAuthenticationStore(authentication);
+            if (authenticationStore != null) {
+                return authenticationStore;
+            }
+        }
+
+        //none found, lets use SimpleJwtAuthenticationStore
+        return jwtAuthenticationStore;
+    }
+
+    @Override
+    public JwtToken getToken(Authentication authentication,
+                             @Nullable @QueryParameter("expiryTimeInMins") Integer expiryTimeInMins,
+                             @Nullable @QueryParameter("maxExpiryTimeInMins") Integer maxExpiryTimeInMins) {
+        if(!Jenkins.getInstance().getACL().hasPermission(authentication, Jenkins.READ)) {
+            // The token endpoint is protected, ie - only issue tokens valid for the authorization strategy
+            throw new AccessDeniedException2(authentication, Jenkins.READ);
+        }
+
+        long expiryTime = Long.getLong("EXPIRY_TIME_IN_MINS", DEFAULT_EXPIRY_IN_SEC);
+
+        int maxExpiryTime = Integer.getInteger("MAX_EXPIRY_TIME_IN_MINS", DEFAULT_MAX_EXPIRY_TIME_IN_MIN);
+
+        if (maxExpiryTimeInMins != null) {
+            maxExpiryTime = maxExpiryTimeInMins;
+        }
+        if (expiryTimeInMins != null) {
+            if (expiryTimeInMins > maxExpiryTime) {
+                throw new ServiceException.BadRequestException(
+                        String.format("expiryTimeInMins %s can't be greater than %s", expiryTimeInMins, maxExpiryTime));
+            }
+            expiryTime = expiryTimeInMins * 60;
+        }
+
+        String userId = authentication.getName();
+
+        User user = User.get(userId, false, Collections.emptyMap());
+        String email = null;
+        String fullName = null;
+        if (user != null) {
+            fullName = user.getFullName();
+            userId = user.getId();
+            Mailer.UserProperty p = user.getProperty(Mailer.UserProperty.class);
+            if (p != null)
+                email = p.getAddress();
+        }
+        Plugin plugin = Jenkins.getInstance().getPlugin("plugin-jwt");
+        String issuer = "plugin-jwt:" + ((plugin != null) ? plugin.getWrapper().getVersion() : "");
+
+        JwtToken jwtToken = new JwtToken();
+        jwtToken.claim.put("jti", UUID.randomUUID().toString().replace("-", ""));
+        jwtToken.claim.put("iss", issuer);
+        jwtToken.claim.put("sub", userId);
+        jwtToken.claim.put("name", fullName);
+        long currentTime = System.currentTimeMillis() / 1000;
+        jwtToken.claim.put("iat", currentTime);
+        jwtToken.claim.put("exp", currentTime + expiryTime);
+        jwtToken.claim.put("nbf", currentTime - DEFAULT_NOT_BEFORE_IN_SEC);
+
+        //set claim
+        JSONObject context = new JSONObject();
+
+        JSONObject userObject = new JSONObject();
+        userObject.put("id", userId);
+        userObject.put("fullName", fullName);
+        userObject.put("email", email);
+
+        JwtAuthenticationStore authenticationStore = getJwtStore(authentication);
+
+        authenticationStore.store(authentication, context);
+
+        context.put("user", userObject);
+        jwtToken.claim.put("context", context);
+
+        return jwtToken;
+    }
+}

--- a/src/main/java/io/jenkins/plugin/auth/jwt/tokens/InternalJwtGenerator.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/tokens/InternalJwtGenerator.java
@@ -62,11 +62,6 @@ public class InternalJwtGenerator extends JwtGenerator {
     private JwtToken generateJwt(Authentication authentication,
                                  @Nullable @QueryParameter("expiryTimeInMins") Integer expiryTimeInMins,
                                  @Nullable @QueryParameter("maxExpiryTimeInMins") Integer maxExpiryTimeInMins) {
-        if(!Jenkins.getInstance().getACL().hasPermission(authentication, Jenkins.READ)) {
-            // The token endpoint is protected, ie - only issue tokens valid for the authorization strategy
-            throw new AccessDeniedException2(authentication, Jenkins.READ);
-        }
-
         long expiryTime = Long.getLong("EXPIRY_TIME_IN_MINS", DEFAULT_EXPIRY_IN_SEC);
 
         int maxExpiryTime = Integer.getInteger("MAX_EXPIRY_TIME_IN_MINS", DEFAULT_MAX_EXPIRY_TIME_IN_MIN);

--- a/src/main/java/io/jenkins/plugin/auth/jwt/tokens/JwtGenerator.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/tokens/JwtGenerator.java
@@ -1,0 +1,38 @@
+package io.jenkins.plugin.auth.jwt.tokens;
+
+import javax.annotation.Nullable;
+
+import org.acegisecurity.Authentication;
+import org.apache.tools.ant.ExtensionPoint;
+import io.jenkins.plugin.auth.jwt.JwtToken;
+
+import hudson.ExtensionList;
+import jenkins.model.Jenkins;
+
+/**
+ * An {@link org.apache.tools.ant.ExtensionPoint} that allows for JWT generation. Many {@link JwtGenerator}s can be
+ * defined to run in Jenkins. The {@link JwtGenerator} with the largest ordinal will be used by Jenkins to generate
+ * a JWT for the user
+ */
+public abstract class JwtGenerator extends ExtensionPoint {
+
+    /**
+     * Get a token for the given user.
+     *
+     * @param authentication the {@link Authentication} (user) to generate a {@link JwtToken} for
+     * @param expiryTimeInMins the requested expiry time in Mins
+     * @param maxExpiryTimeInMins the maximum expiry time in mins
+     * @return The generated {@link JwtToken}
+     */
+    public abstract JwtToken getToken(Authentication authentication,
+                                      @Nullable Integer expiryTimeInMins,
+                                      @Nullable Integer maxExpiryTimeInMins);
+
+    /**
+     * Gets all {@link JwtGenerator}s
+     * @return all of them
+     */
+    public static ExtensionList<JwtGenerator> all() {
+        return Jenkins.getInstance().getExtensionList(JwtGenerator.class);
+    }
+}

--- a/src/main/java/io/jenkins/plugin/auth/jwt/tokens/JwtGenerator.java
+++ b/src/main/java/io/jenkins/plugin/auth/jwt/tokens/JwtGenerator.java
@@ -2,9 +2,10 @@ package io.jenkins.plugin.auth.jwt.tokens;
 
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.acegisecurity.Authentication;
 import org.apache.tools.ant.ExtensionPoint;
-import io.jenkins.plugin.auth.jwt.JwtToken;
 
 import hudson.ExtensionList;
 import jenkins.model.Jenkins;
@@ -19,14 +20,14 @@ public abstract class JwtGenerator extends ExtensionPoint {
     /**
      * Get a token for the given user.
      *
-     * @param authentication the {@link Authentication} (user) to generate a {@link JwtToken} for
+     * @param authentication the {@link Authentication} (user) to generate a token for
      * @param expiryTimeInMins the requested expiry time in Mins
      * @param maxExpiryTimeInMins the maximum expiry time in mins
-     * @return The generated {@link JwtToken}
+     * @return The generated token response
      */
-    public abstract JwtToken getToken(Authentication authentication,
-                                      @Nullable Integer expiryTimeInMins,
-                                      @Nullable Integer maxExpiryTimeInMins);
+    public abstract OAuthAccessTokenResponse getToken(Authentication authentication,
+                                                      @Nullable Integer expiryTimeInMins,
+                                                      @Nullable Integer maxExpiryTimeInMins);
 
     /**
      * Gets all {@link JwtGenerator}s
@@ -34,5 +35,23 @@ public abstract class JwtGenerator extends ExtensionPoint {
      */
     public static ExtensionList<JwtGenerator> all() {
         return Jenkins.getInstance().getExtensionList(JwtGenerator.class);
+    }
+
+    @JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+    public static final class OAuthAccessTokenResponse {
+        public final String accessToken;
+        public final String tokenType;
+        public final long expiresIn; // seconds
+
+        /**
+         * Create a new OAuth access token response
+         * @param accessToken the access token
+         * @param expiresIn the number of seconds that the token will be valid for
+         */
+        public OAuthAccessTokenResponse(String accessToken, long expiresIn) {
+            this.accessToken = accessToken;
+            this.tokenType = "bearer";
+            this.expiresIn = expiresIn;
+        }
     }
 }


### PR DESCRIPTION
This allows other plugins to override the JWT creation to allow different access tokens to be created